### PR TITLE
Enable packaging in derivative MSYS2 environments for ca-certificates and crt

### DIFF
--- a/mingw-w64-ca-certificates/PKGBUILD
+++ b/mingw-w64-ca-certificates/PKGBUILD
@@ -108,6 +108,7 @@ EOF
 }
 
 package() {
+  sed -e "s|@PREFIX@|${MSYSTEM,,}|" "$startdir/ca-certificates.install.in" > "$startdir/ca-certificates-${MSYSTEM}.install"
   cd "${srcdir}"/${_realname}-${pkgver}
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/{bin,lib,share}

--- a/mingw-w64-ca-certificates/ca-certificates.install.in
+++ b/mingw-w64-ca-certificates/ca-certificates.install.in
@@ -1,0 +1,26 @@
+export LC_ALL=C
+
+post_install() {
+  local _mingw_prefix=@PREFIX@
+  DEST=${_mingw_prefix}/etc/pki/ca-trust/extracted
+
+  # OpenSSL PEM bundle that includes trust flags
+  # (BEGIN TRUSTED CERTIFICATE)
+  ${_mingw_prefix}/bin/p11-kit.exe extract --format=openssl-bundle --filter=certificates --overwrite --comment $DEST/openssl/ca-bundle.trust.crt
+  ${_mingw_prefix}/bin/p11-kit.exe extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $DEST/pem/tls-ca-bundle.pem
+  ${_mingw_prefix}/bin/p11-kit.exe extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose email $DEST/pem/email-ca-bundle.pem
+  ${_mingw_prefix}/bin/p11-kit.exe extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose code-signing $DEST/pem/objsign-ca-bundle.pem
+  ${_mingw_prefix}/bin/p11-kit.exe extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth $DEST/java/cacerts
+
+  mkdir -p ${_mingw_prefix}/etc/ssl/certs
+  cp -f $DEST/pem/tls-ca-bundle.pem ${_mingw_prefix}/etc/ssl/certs/ca-bundle.crt
+  cp -f $DEST/pem/tls-ca-bundle.pem ${_mingw_prefix}/etc/ssl/cert.pem
+  cp -f $DEST/openssl/ca-bundle.trust.crt ${_mingw_prefix}/etc/ssl/certs/ca-bundle.trust.crt
+
+  #${_mingw_prefix}/bin/update-ca-trust >/dev/null 2>&1
+}
+
+post_upgrade() {
+  post_install
+}
+

--- a/mingw-w64-crt/PKGBUILD
+++ b/mingw-w64-crt/PKGBUILD
@@ -68,7 +68,7 @@ build() {
     _extra_config+=("--enable-cfguard")
   fi
 
-  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]] || [[ $MINGW_PACKAGE_PREFIX == *-ucrt-* ]]; then
+  if [[ $MINGW_PACKAGE_PREFIX == *-clang-* ]] || [[ $MINGW_PACKAGE_PREFIX == *-ucrt* ]]; then
     _extra_config+=("--with-default-msvcrt=ucrt")
   else
     _extra_config+=("--with-default-msvcrt=msvcrt")


### PR DESCRIPTION
These changes are necessary if starting a separate MSYS2 environment for MCF as discussed in #19.